### PR TITLE
fix bug about function to fork group with groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -41,17 +41,17 @@ class GroupsController < ApplicationController
             group_attribute.delete('id')
             group_attribute.delete('created_at')
             group_attribute.delete('updated_at')
-            @group = Group.new(group_attribute.merge({:user_id => current_user.id, :parent_id => new_parent_id}))
+            @group = Group.new(group_attribute.merge({:user_id => current_user.id, :parent_id => new_parent_id, :visible => 0}))
             @group.save
+
             @tasks = Task.where(group_id: group.id)
-            
             @tasks.each do |task|
               task_attribute = task.attributes
-
               task_attribute.delete('id')
               task_attribute.delete('created_at')
               task_attribute.delete('updated_at')
-              @task = Task.new(task_attribute.merge({:user_id => current_user.id, :group_id => new_parent_id}))
+
+              @task = Task.new(task_attribute.merge({:user_id => current_user.id, :group_id => @group.id}))
               @task.save
             end
 
@@ -72,8 +72,21 @@ class GroupsController < ApplicationController
     attribute = @group[0].attributes
     attribute.delete('id')
 
-    @parent_group = Group.new(attribute.merge({:user_id => current_user.id}))
+    @parent_group = Group.new(attribute.merge({:user_id => current_user.id, :visible => 0}))
     @parent_group.save
+
+    @tasks = Task.where(group_id: params[:id])
+
+    @tasks.each do |task|
+      task_attribute = task.attributes
+      task_attribute.delete('id')
+      task_attribute.delete('created_at')
+      task_attribute.delete('updated_at')
+
+      @task = Task.new(task_attribute.merge({:user_id => current_user.id, :group_id => @parent_group.id}))
+      @task.save
+    end
+
     search(params[:id], @parent_group.id)
 
     respond_to do |format|

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -145,7 +145,12 @@ class TasksController < ApplicationController
 
     priority = params['task']['importance'].to_i * urgency
 
-    params['task']['user_id'] = current_user.id
+    if params['task'].key?('id')
+      params['task']['user_id'] = Task.find(params['task']['id']).user_id
+    else
+      params['task']['user_id'] = current_user.id
+    end
+
     params['task']['urgency'] = urgency
     params['task']['priority'] = priority
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,9 +12,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # POST /resource
   def create
     super
+
     group = Group.create(
       name: "general",
-      user_id: current_user.id
+      user_id: @user.id
     )
     
     group.save

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,8 +1,17 @@
 <div class="container">
-	<h1>タスクを編集する</h1>
+	<% if @task.user_id == current_user.id %>
 
-	<%= render 'form', task: @task %>
+		<h1>タスクを編集する</h1>
 
-	<%= link_to 'タスクを表示', @task %> |
-	<%= link_to 'タスク一覧に戻る', tasks_path %>
-</div>
+		<%= render 'form', task: @task %>
+
+		<%= link_to 'タスクを表示', @task %> |
+		<%= link_to 'タスク一覧に戻る', tasks_path %>
+	</div>
+  <% else %>
+    <div class="attention">
+      <i class="fas fa-exclamation-circle"></i>
+        <p>タスクへのアクセス権がありません。</p>
+        <%= link_to 'タスク一覧へ戻る', tasks_path %>
+    </div>
+  <% end %>


### PR DESCRIPTION
・Forkしたグループの公開状態が、非公開状態になるようにしました。
・Forkしたグループに属したタスクも正常にコピーされるようになりました。
・公開されている他人のグループに属したタスクを乗っ取れるバグを修正しました。