### PR TITLE
Fix/delete tasks and groups

### DIFF
--- a/app/controllers/concerns/group_util.rb
+++ b/app/controllers/concerns/group_util.rb
@@ -1,12 +1,13 @@
 module GroupUtil
   extend ActiveSupport::Concern
 
-  def get_ancestor_groups(group)
-    ancestors = [group]
-    current_node = group
+  def get_ancestor_groups(current_node)
+    ancestors = [current_node]
+
     while current_node = Group.where(id: current_node.parent_id)[0] do
       ancestors.push(current_node)
     end
+    
     return ancestors.reverse!
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -63,11 +63,6 @@ class GroupsController < ApplicationController
       #return new_parent_id
     end
 
-    # respond_to do |format|
-    #   format.html { redirect_to groups_url, notice: attribute }
-    #   format.json { head :no_content }
-    # end
-
     @group = Group.where(id: params[:id])
     attribute = @group[0].attributes
     attribute.delete('id')
@@ -90,7 +85,7 @@ class GroupsController < ApplicationController
     search(params[:id], @parent_group.id)
 
     respond_to do |format|
-      format.html { redirect_to groups_url, notice: 'グループをフォークしました。。' }
+      format.html { redirect_to groups_url, notice: 'グループをフォークしました。' }
       format.json { head :no_content }
     end
     
@@ -104,7 +99,7 @@ class GroupsController < ApplicationController
 
     respond_to do |format|
       if @group.save
-        format.html { redirect_to @group, notice: 'Group was successfully created.' }
+        format.html { redirect_to @group, notice: 'グループが作成されました。' }
         format.json { render :show, status: :created, location: @group }
       else
         format.html { render :new }
@@ -118,7 +113,7 @@ class GroupsController < ApplicationController
   def update
     respond_to do |format|
       if @group.update(group_params)
-        format.html { redirect_to @group, notice: 'Group was successfully updated.' }
+        format.html { redirect_to @group, notice: 'グループが更新されました。' }
         format.json { render :show, status: :ok, location: @group }
       else
         format.html { render :edit }
@@ -130,7 +125,33 @@ class GroupsController < ApplicationController
   # DELETE /groups/1
   # DELETE /groups/1.json
   def destroy
+    def search(parent_id)
+      while true do
+        @groups = Group.where(parent_id: parent_id)
+        if @groups.empty?
+          break
+        else
+          @groups.each do |group|
+            @tasks = Task.where(group_id: group.id)
+            @tasks.each do |task|
+              task.destroy
+            end
+            search(group.id)
+            group.destroy
+          end
+          break
+        end
+      end
+      #return new_parent_id
+    end
+
+    search(@group.id)
+    @tasks = Task.where(group_id: @group.id)
+    @tasks.each do |task|
+      task.destroy
+    end
     @group.destroy
+    
     respond_to do |format|
       format.html { redirect_to groups_url, notice: 'Group was successfully destroyed.' }
       format.json { head :no_content }

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -32,9 +32,18 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # DELETE /resource
-  # def destroy
-  #   super
-  # end
+  def destroy
+    super
+    @tasks = Task.where(user_id: @user.id)
+    @tasks.each do |task|
+      task.destroy
+    end
+
+    @groups = Group.where(user_id: @user.id)
+    @groups.each do |group|
+      group.destroy
+    end
+  end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign


### PR DESCRIPTION
- グループを削除時に、子グループと子タスクが同時に削除されない問題を修正しました
- groupcontrollerの delete メソッドに再帰的にグループ・タスクを削除する機能をつけました。
- RegistrationsControllerのdestroyメソッドに再帰的にグループ・タスクを削除する機能をつけました。