### PR TITLE
set default timezone of rails as the one of Japan

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,10 @@ module Myapp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
     config.i18n.default_locale = :ja
+    
+    # setting for TimeZone
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
# 変更点
<!--- ここはコメントアウト、必要に応じて外してください --->
<!--- ## ライブラリの追加 --->
<!--- * --->

<!--- ## 機能追加 --->
<!--- * --->


## 機能修正
* `config/application.rb` に日本のタイムゾーンの設定を追加
   + [Railsタイムゾーンまとめ - Qiita](https://qiita.com/aosho235/items/a31b895ce46ee5d3b444) を参考にRails内部はJSTに統一した。
   + heroku環境での対応については追加調査が必要

# コメント
