### PR TITLE
fix the error occurred while importing seed file because of strict check to enum type

### DIFF
--- a/db/fixtures/development/task.rb
+++ b/db/fixtures/development/task.rb
@@ -6,7 +6,7 @@ csv.each do |task|
 		s.id = task[0]
 		s.name = task[1]
 		s.importance = task[2]
-		s.status = task[3]
+		s.status = task[3].to_i
 		s.group_id = task[4]
 		s.deadline = DateTime.new(2019, 1, 1, 00, 00, 00)
 	end


### PR DESCRIPTION


# 変更点
<!--- ここはコメントアウト、必要に応じて外してください --->
<!--- ## ライブラリの追加 --->
<!--- * --->

<!--- ## 機能追加 --->
<!--- * --->


## 機能修正
* taskをseedから生成時にstatusをenum型にしたことによって発生するエラーを解消

# コメント
