### PR TITLE
rename crap column in task model into calp

### DIFF
--- a/db/migrate/20181207222550_rename_crap_column_to_tasks.rb
+++ b/db/migrate/20181207222550_rename_crap_column_to_tasks.rb
@@ -1,0 +1,5 @@
+class RenameCrapColumnToTasks < ActiveRecord::Migration[5.1]
+  def change
+  	rename_column :tasks, :crap, :clap
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181207051157) do
+ActiveRecord::Schema.define(version: 20181207222550) do
 
   create_table "audio_tests", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 20181207051157) do
     t.integer "urgency"
     t.integer "priority"
     t.integer "group_id", null: false
-    t.integer "crap", default: 0, null: false
+    t.integer "clap", default: 0, null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
# 変更点
<!--- ここはコメントアウト、必要に応じて外してください --->
<!--- ## ライブラリの追加 --->
<!--- * --->

<!--- ## 機能追加 --->
<!--- * --->


## 機能修正
* Columnテーブルのcrapフィールドをclapに修正

# コメント
