### PR TITLE
Feature/add strict validation to contribution

### DIFF
--- a/app/graphql/types/contribution_type.rb
+++ b/app/graphql/types/contribution_type.rb
@@ -3,6 +3,15 @@ class Types::ContributionType < Types::BaseObject
   field :user_id, ID, 'ユーザーID', null: false
   field :task_id, ID, 'タスクID', null: false
   field :created_at, Types::MomentType, '開始時刻', null: false
-  field :finish_time, Types::MomentType, '終了時刻', null: true
-  field :is_finish?, Boolean, 'このコントリビューションでタスクを終了したか否か', null: true
+  field :finished_at, Types::MomentType, '終了時刻', null: true
+  field :status, Boolean, null: false
+  field :finality, Boolean, 'このコントリビューションでタスクを終了したか否か', null: false
+
+  def status
+  	Contribution.statuses[object.status]
+  end
+
+  def finality
+  	Contribution.finality[object.finality]
+  end
 end

--- a/app/graphql/types/contribution_type.rb
+++ b/app/graphql/types/contribution_type.rb
@@ -4,14 +4,14 @@ class Types::ContributionType < Types::BaseObject
   field :task_id, ID, 'タスクID', null: false
   field :created_at, Types::MomentType, '開始時刻', null: false
   field :finished_at, Types::MomentType, '終了時刻', null: true
-  field :status, Boolean, null: false
-  field :finality, Boolean, 'このコントリビューションでタスクを終了したか否か', null: false
+  field :status, Boolean, 'コントリビューションの状態(true: active, false: inactive)', null: false
+  field :finality, Boolean, 'このコントリビューションでタスクを終了したか否か(true: final, false: not_final)', null: false
 
   def status
   	Contribution.statuses[object.status]
   end
 
   def finality
-  	Contribution.finality[object.finality]
+  	Contribution.finalities[object.finality]
   end
 end

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -5,5 +5,5 @@ class Contribution < ApplicationRecord
   enum finality: { final: true, not_final: false }
   enum status: { active: true, inactive: false }
 
-  validates :status, uniqueness: { scope: [:user_id, :task_id], on: :create }
+  validates :status, uniqueness: { scope: [:user_id, :task_id], on: :save }
 end

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -1,4 +1,9 @@
 class Contribution < ApplicationRecord
   belongs_to :user
   belongs_to :task
+
+  enum finality: { final: true, not_final: false }
+  enum status: { active: true, inactive: false }
+
+  validates :status, uniqueness: { scope: [:user_id, :task_id], on: :create }
 end

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -5,5 +5,5 @@ class Contribution < ApplicationRecord
   enum finality: { final: true, not_final: false }
   enum status: { active: true, inactive: false }
 
-  validates :status, uniqueness: { scope: [:user_id, :task_id], on: :save }
+  validates :status, uniqueness: { scope: [:user_id, :task_id], if: 'active?' }
 end

--- a/db/migrate/20181213200431_add_status_column_to_contribution.rb
+++ b/db/migrate/20181213200431_add_status_column_to_contribution.rb
@@ -1,0 +1,5 @@
+class AddStatusColumnToContribution < ActiveRecord::Migration[5.1]
+  def change
+  	add_column :contributions, :status, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20181213201322_rename_is_final_column_in_contribution.rb
+++ b/db/migrate/20181213201322_rename_is_final_column_in_contribution.rb
@@ -1,0 +1,5 @@
+class RenameIsFinalColumnInContribution < ActiveRecord::Migration[5.1]
+  def change
+  	rename_column :contributions, :is_finish?, :finality
+  end
+end

--- a/db/migrate/20181213201644_rename_finish_time_column_in_contribution.rb
+++ b/db/migrate/20181213201644_rename_finish_time_column_in_contribution.rb
@@ -1,0 +1,5 @@
+class RenameFinishTimeColumnInContribution < ActiveRecord::Migration[5.1]
+  def change
+  	rename_column :contributions, :finish_time, :finished_at
+  end
+end

--- a/db/migrate/20181213202158_add_nullability_to_columns_of_contribution.rb
+++ b/db/migrate/20181213202158_add_nullability_to_columns_of_contribution.rb
@@ -1,0 +1,7 @@
+class AddNullabilityToColumnsOfContribution < ActiveRecord::Migration[5.1]
+  def change
+  	change_column_null :contributions, :user_id, false
+  	change_column_null :contributions, :task_id, false
+  	change_column_null :contributions, :finality, false
+  end
+end

--- a/db/migrate/20181213203003_set_default_of_finality_in_contribution.rb
+++ b/db/migrate/20181213203003_set_default_of_finality_in_contribution.rb
@@ -1,0 +1,5 @@
+class SetDefaultOfFinalityInContribution < ActiveRecord::Migration[5.1]
+  def change
+  	change_column_default :contributions, :finality, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181209235432) do
-  
+ActiveRecord::Schema.define(version: 20181213203003) do
+
   create_table "audio_tests", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "contributions", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "task_id", null: false
+    t.datetime "finished_at"
+    t.boolean "finality", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "status", default: true, null: false
+    t.index ["task_id"], name: "index_contributions_on_task_id"
+    t.index ["user_id"], name: "index_contributions_on_user_id"
   end
 
   create_table "groups", force: :cascade do |t|


### PR DESCRIPTION
# 変更点
<!--- ここはコメントアウト、必要に応じて外してください --->
<!--- ## ライブラリの追加 --->
<!--- * --->

## 機能追加
* statusカラムをcontributionテーブルに追加
* contribution作成時のバリデーションを追加
   + ~コントリビューション保存時に~ コントリビューション保存時、新規コントリビューションのステータスがactiveである場合にuser_id, task_id, statusの値の組の一意性を検証
      -> 一人のユーザーが同一タスクに同時にコントリビューションを作成することを防ぐ


## 機能修正
* contributionテーブルのカラム名変更
   + is_final?カラムの名前をfinalityに変更
   + finish_timeカラムの名前をfinished_atに変更
* contributionテーブルのuser_id, task_id, finalityカラムにnull: falseを設定
* contributionテーブルのfinalityカラムのデフォルト値をfalseに設定
* contributionモデルのstatus, finalityをenumとして定義
* contributionクエリをモデルの変更に追随するよう修正

# コメント
