### PR TITLE
Add Public Groups Query

### DIFF
--- a/app/graphql/mutations/create_group.rb
+++ b/app/graphql/mutations/create_group.rb
@@ -17,7 +17,7 @@ class Mutations::CreateGroup < GraphQL::Schema::Mutation
       return { group: parent_group, errors: ['specified parent group is not yours.'] }
     end
     group = Group.new(:parent_id => parent_id, :name => name, :user_id => context[:current_user].id, :importance => importance, :deadline => deadline)
-    group.publicity = publicity if !publicity.nil?
+    group.public = publicity if !publicity.nil?
     if group.save
       { group: group, errors: [] }
     else

--- a/app/graphql/types/group_type.rb
+++ b/app/graphql/types/group_type.rb
@@ -17,6 +17,10 @@ class Types::GroupType < Types::BaseObject
     object.tasks
   end
 
+  def groups
+    object[:groups]
+  end
+  
   def parent_group
     Group.find(object.parent_id) if !object.parent_id.nil?
   end

--- a/app/graphql/types/publicgroup_type.rb
+++ b/app/graphql/types/publicgroup_type.rb
@@ -1,0 +1,13 @@
+class Types::PublicgroupType < Types::BaseObject
+  field :groups, Types::GroupType, '日付', null: false
+  field :users, Types::UserType, 'その日の終了コントリビューション', null: false
+
+  def groups
+    object[:groups]
+  end
+
+  def users
+    object[:users]
+  end
+
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -33,6 +33,10 @@ class Types::QueryType < Types::BaseObject
     description '指定したIDを持つユーザーのを日付ごとにまとめた終了タスクと終了コントリビューションを配列として返す'
     argument :user_id, ID, 'ユーザーID', required: true
   end
+  
+  field :publicgroup, [Types::PublicgroupType], null: true do
+    description '公開グループを配列として返す'
+  end
 
   def me
     User.find(context[:current_user].id)
@@ -92,5 +96,14 @@ class Types::QueryType < Types::BaseObject
     grouped_contributions.map{ |idx, val|
       grouped_tasks[:idx].nil? ? { :date => idx, :contributions => val, :tasks => [] } : { :date => idx, :contributions => val, :tasks => grouped_tasks[:idx] }
     }
+  end
+
+  def publicgroup
+    publicgroups = []
+    groups = Group.where(public: true)
+    groups.each { |group|
+      publicgroups.push({:groups => group, :users => User.find(group.user_id)})
+    }
+    return publicgroups
   end
 end


### PR DESCRIPTION
## 機能追加
* Publicグループのみを返すQueryの追加
(Userモデルへの参照が多いため、遅いのが非常に問題です)
